### PR TITLE
Adiciona projeto de testes xUnit com dependências básicas

### DIFF
--- a/api/api.sln
+++ b/api/api.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35806.99 d17.13
+VisualStudioVersion = 17.13.35806.99
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api_sistema_de_chamado", "api_sistema_de_chamado\api_sistema_de_chamado.csproj", "{E6B8BF10-965A-4A1B-A6B0-10C4644A81C5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api_sistema_de_chamado_tests", "api_sistema_de_chamado_tests\api_sistema_de_chamado_tests.csproj", "{7B73951B-79E0-437B-A937-80E5AF4314C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{E6B8BF10-965A-4A1B-A6B0-10C4644A81C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6B8BF10-965A-4A1B-A6B0-10C4644A81C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6B8BF10-965A-4A1B-A6B0-10C4644A81C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B73951B-79E0-437B-A937-80E5AF4314C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B73951B-79E0-437B-A937-80E5AF4314C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B73951B-79E0-437B-A937-80E5AF4314C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B73951B-79E0-437B-A937-80E5AF4314C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/api/api_sistema_de_chamado_tests/UnitTest1.cs
+++ b/api/api_sistema_de_chamado_tests/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace api_sistema_de_chamado_tests
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}

--- a/api/api_sistema_de_chamado_tests/api_sistema_de_chamado_tests.csproj
+++ b/api/api_sistema_de_chamado_tests/api_sistema_de_chamado_tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\api_sistema_de_chamado\api_sistema_de_chamado.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adicionado projeto de testes com xUnit à solução da API, configurado com as dependências principais e referência ao projeto principal. A estrutura está preparada para receber os primeiros testes unitários e de integração

